### PR TITLE
Fix replacement policy update on cache miss

### DIFF
--- a/byte_chomp/cache.py
+++ b/byte_chomp/cache.py
@@ -36,15 +36,15 @@ class Cache(BaseModel):
             self.performance_stats.hits += 1
             self.replacement_policy.update_access(index, slot)
         else:
-            self._replace_cache_line(tag, index)
-            self.replacement_policy.update_access(index, slot)
+            replacement_slot = self._replace_cache_line(tag, index)
+            self.replacement_policy.update_access(index, replacement_slot)
 
     def _decode_address(self, address: int) -> tuple[int, int]:
         index = (address >> self.offset_bits) & ((1 << self.index_bits) - 1)
         tag = address >> (self.offset_bits + self.index_bits)
         return index, tag
 
-    def _replace_cache_line(self, tag: int, index: int):
+    def _replace_cache_line(self, tag: int, index: int) -> int:
         cache_line = self.cache_table.get_cache_line(index)
         replacement_slot = self.replacement_policy.select_replacement_slot(
             index, cache_line
@@ -59,6 +59,7 @@ class Cache(BaseModel):
 
         new_entry = {"tag": tag}
         self.cache_table.update_cache_line(index, replacement_slot, new_entry)
+        return replacement_slot
 
 
 def get_cache_from_config(config: CacheConfig):


### PR DESCRIPTION
## Summary
- ensure replacement policies receive the correct slot when a miss occurs

## Testing
- `python -m py_compile byte_chomp/*.py cache_simulator.py tests/*.py`
- `pytest -q` *(fails: pytest not installed)*